### PR TITLE
Reverse sorting order

### DIFF
--- a/notmuch-addrlookup.c
+++ b/notmuch-addrlookup.c
@@ -64,9 +64,9 @@ sort_by_frequency (gconstpointer data1,
       (info1->occurrences[0] == info2->occurrences[0] &&
        info1->occurrences[1] == info2->occurrences[1] &&
        info1->occurrences[2] <  info2->occurrences[2]))
-    return -1;
+    return 1;
 
-  return 1;
+  return -1;
 }
 
 


### PR DESCRIPTION
Hi there, thanks for this awesome and cleanly written tool!

I've been using this for a few days now and realised after a while that the order in which it outputs email addresses seemed inversely correlated to how many emails I had exchanged with those addresses. Changing `sort_by_frequency` as in this patch made things work as expected for me.