### PR TITLE
notmuch_message_get_header() can return NULL

### DIFF
--- a/notmuch-addrlookup.c
+++ b/notmuch-addrlookup.c
@@ -244,6 +244,8 @@ run_queries (notmuch_database_t *db,
           for (guint j = 0; headers[j] != NULL; j++)
             {
               const gchar* froms = notmuch_message_get_header (msg, headers[j]);
+              if (!froms || *froms == '\0')
+                continue;
 
               GMatchInfo *matches;
               g_regex_match (match_re, froms, 0, &matches);


### PR DESCRIPTION
If there's a mail without the header to search the function
notmuch_message_get_header() returns NULL, which is not handled
by the code right now, leading to a critical warning and a
following segmentation fault in g_match_info_matches() when using
libglib-2.50.2-2 (it is already fixed in master).

This patch checks if the return value is NULL and if so continues
in the next iteration.