### PR TITLE
fix notmuch version tests for version 5

### DIFF
--- a/notmuch-addrlookup.c
+++ b/notmuch-addrlookup.c
@@ -164,7 +164,7 @@ create_queries (notmuch_database_t *db,
   queries[1] = notmuch_query_create (db, sbuf);
   g_free (sbuf);
 
-#if LIBNOTMUCH_MAJOR_VERSION >= 4 && LIBNOTMUCH_MINOR_VERSION >= 3
+#if LIBNOTMUCH_MAJOR_VERSION >= 5 || (LIBNOTMUCH_MAJOR_VERSION >= 4 && LIBNOTMUCH_MINOR_VERSION >= 3)
   unsigned int count = 0;
   unsigned int tmp;
   if (notmuch_query_count_messages_st (queries[0], &tmp) == NOTMUCH_STATUS_SUCCESS)
@@ -230,7 +230,7 @@ run_queries (notmuch_database_t *db,
       const gchar **headers = (i == 1) ? headers_pass1 : headers_pass0;
       notmuch_messages_t *messages = NULL;
 
-#if LIBNOTMUCH_MAJOR_VERSION >= 4 && LIBNOTMUCH_MINOR_VERSION >= 3
+#if LIBNOTMUCH_MAJOR_VERSION >= 5 || (LIBNOTMUCH_MAJOR_VERSION >= 4 && LIBNOTMUCH_MINOR_VERSION >= 3)
       if (notmuch_query_search_messages_st (queries[i], &messages) != NOTMUCH_STATUS_SUCCESS)
           continue;
 #else


### PR DESCRIPTION
The previous version of the test missed the major version bump

You might have a look look at the new API and get rid of the the _st versions; here I just did the minimal diff to get it to build with notmuch 0.25