### PR TITLE
name <email>, not name  <email>

### DIFF
--- a/notmuch-addrlookup.c
+++ b/notmuch-addrlookup.c
@@ -265,6 +265,7 @@ run_queries (notmuch_database_t *db,
                   gboolean has_space = strchr (from, ' ') != NULL;
                   gchar *name = has_space ? g_match_info_fetch_named (matches, "name") : g_strdup (from);
                   gchar *addr = has_space ? g_match_info_fetch_named (matches, "mail") : g_strdup (from);
+                  g_strstrip(name); /* Name should be 'Bob', not 'Bob ' */
                   gchar *patt = g_strdup_printf ("\\b%s", query_name);
 
                   if (g_regex_match_simple (patt, from, G_REGEX_CASELESS, 0))


### PR DESCRIPTION
$ notmuch-addrlookup bob
Bob  <bob@example.com> # no!
Bob <bob@example.com> # yes

This removes the second space formerly produced between name and email
in Message[Notmuch] mode when using

  (setq notmuch-address-command "notmuch-addrlookup")

Whether this breaks mutt, I do not know.