### PR TITLE
adds option to specfiy config as command line argument

### DIFF
--- a/notmuch-addrlookup.c
+++ b/notmuch-addrlookup.c
@@ -18,10 +18,13 @@ static gchar* notmuch_database_path = NULL;
 static gchar* notmuch_user_email = NULL;
 static gchar** search_terms = NULL;
 static gboolean mutt_output = FALSE;
+static gchar* notmuch_config_path = NULL;
 
 static const GOptionEntry option_entries[] = {
   { "mutt", 'm', 0, G_OPTION_ARG_NONE, &mutt_output,
     "Format output for Mutt", NULL },
+  { "config", 'c', 0, G_OPTION_ARG_STRING, &notmuch_config_path,
+    "Path to config file .notmuch-config", NULL },
   { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_STRING_ARRAY, &search_terms,
     "Search terms", NULL },
   { NULL }
@@ -94,8 +97,11 @@ load_notmuch_settings (void)
 
   if (g_getenv ("NOTMUCH_CONFIG"))
     config_path = g_strdup (g_getenv ("NOTMUCH_CONFIG"));
-  else
+  else if(!notmuch_config_path)
     config_path = g_strdup_printf ("%s/.notmuch-config", g_get_home_dir ());
+  else
+    config_path = notmuch_config_path;
+
 
   if (!g_key_file_load_from_file (key_file,
                                   config_path,


### PR DESCRIPTION
I just forked the repo to add an option to specfiy the config file as another option besides using `~/.notmuch-config` or using an environment variable `NOTMUCH_CONFIG` like it can be done with notmuch directly. I thought I might as well create a pull request if anyone is interested. 