### PR TITLE
Respect notmuch-config(1) FILES specs.

### DIFF
--- a/notmuch-addrlookup.c
+++ b/notmuch-addrlookup.c
@@ -96,13 +96,19 @@ load_notmuch_settings (void)
   gchar *config_path = NULL;
   gboolean success = FALSE;
 
-  if (g_getenv ("NOTMUCH_CONFIG"))
-    config_path = g_strdup (g_getenv ("NOTMUCH_CONFIG"));
-  else if(!notmuch_config_path_lookupvar)
-    config_path = g_strdup_printf ("%s/.notmuch-config", g_get_home_dir ());
-  else
+  if(notmuch_config_path_lookupvar)
     config_path = notmuch_config_path_lookupvar;
+  else if (g_getenv ("NOTMUCH_CONFIG"))
+    config_path = g_strdup (g_getenv ("NOTMUCH_CONFIG"));
+  else if (g_getenv ("NOTMUCH_PROFILE")){
+    if (g_getenv("XDG_CONFIG_HOME")){
+      //TODO check if file exists
+    }
+  }
+  else
+    config_path = g_strdup_printf ("%s/.notmuch-config", g_get_home_dir ());
 
+  g_print("%s\n", config_path);
 
   if (!g_key_file_load_from_file (key_file,
                                   config_path,
@@ -110,10 +116,11 @@ load_notmuch_settings (void)
                                   NULL))
     goto bailout;
 
-  notmuch_database_path = g_key_file_get_string (key_file,
-                                                 "database",
-                                                 "path",
-                                                 NULL);
+
+  if (g_getenv ("NOTMUCH_DATABASE"))
+    notmuch_database_path = g_strdup (g_getenv ("NOTMUCH_DATABASE"));
+  else if (g_key_file_get_string (key_file, "database", "path", NULL))
+    notmuch_database_path = g_key_file_get_string (key_file, "database", "path", NULL);
 
   notmuch_user_email = g_key_file_get_string (key_file,
                                               "user",


### PR DESCRIPTION
WIP

Questions and comments:
- I would make `--config` supersede any environment variables (the same as the notmuch command itself)
- To actually conform to the specs, I'd need to check at each stage whether the file actually exists and go to the next one if it doesn't, otherwise we'll never get to `$HOME/.notmuch-config`. I did a quick search of how you do this in C, but as there are multiple ways and nothing really popped out as appropriate, what do you prefer for that? In the end I need a function that returns a true or false :)
- I'd probably add a `G_OPTION_ARG_NONE` type `--debug` flag which prints which config file / database is actually used in the end, or maybe at that point maybe the "check file exists" func could print each file it tries, otherwise I think it might get confusing if things don't work as expected.